### PR TITLE
Support gatsby v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "jest": "^26.6.3"
   },
   "peerDependencies": {
-    "gatsby": ">=2.32.3"
+    "gatsby": "^2.32.3 || ^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "jest": "^26.6.3"
   },
   "peerDependencies": {
-    "gatsby": "^2.32.3"
+    "gatsby": ">=2.32.3"
   }
 }


### PR DESCRIPTION
When I tried to upgrade gatsby v3, I see this warning:
```
warn Plugin gatsby-plugin-opensearch is not compatible with your gatsby version 3.1.2 - It
requires gatsby@^2.32.3
```
As gatsby published their new version, we need to update the `peerDependencies` version.
I have checked the [migration guide](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/). I think there is nothing need to change 🙂 